### PR TITLE
Add additional systems to flake outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,12 @@
     flake-parts.lib.mkFlake
       { inherit inputs; }
       {
-        systems = [ "x86_64-linux" ];
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "aarch64-darwin"
+        ];
 
         imports = [
           inputs.treefmt-nix.flakeModule


### PR DESCRIPTION
Hello,

Flake outputs are currently restricted to `x86_64-linux`, any objections to adding `aarch64` and darwin outputs? Test suite passes at least on `aarch64-darwin` as well.

Thank you so much for this! :)