### PR TITLE
Add simple inequality comparison to PEP508 markers

### DIFF
--- a/lib/pep508.nix
+++ b/lib/pep508.nix
@@ -73,6 +73,7 @@ let
 
   compareOps = pep440.comparators // {
     "==" = x: y: x == y; # Simple equality
+    "!=" = x: y: x != y;
   };
 
   boolOps = {

--- a/lib/test_pep508.nix
+++ b/lib/test_pep508.nix
@@ -64,6 +64,28 @@ fix (self: {
       };
     };
 
+    testInequalityMarker = {
+      input = "brotlicffi; platform_python_implementation != \"CPython\"";
+      expected = {
+        name = "brotlicffi";
+        conditions = [ ];
+        extras = [ ];
+        markers = {
+          op = "!=";
+          type = "compare";
+          lhs = {
+            type = "variable";
+            value = "platform_python_implementation";
+          };
+          rhs = {
+            type = "string";
+            value = "CPython";
+          };
+        };
+        url = null;
+      };
+    };
+
     testVersionedWithDoubleConditions = {
       input = "packaging>=20.9,!=22.0";
       expected = {
@@ -775,6 +797,14 @@ fix (self: {
         inherit (self.parseString.testDoubleMarkersWithExtras.expected) markers;
       };
       expected = false;
+    };
+
+    testRepro = {
+      input = {
+        environ = self.mkEnviron.testPypy3Linux.expected;
+        inherit (self.parseString.testInequalityMarker.expected) markers;
+      };
+      expected = true;
     };
   };
 })


### PR DESCRIPTION
Hello,

Before this PR, calling `pep508.evalMarkers` on a string like `brotlicffi; platform_python_implementation != \"CPython\""` fails with the stacktrace below.

This seems to be the case because `pep440.comparators."!="` calls `compareVersions` on a comparision of `python_platform_implementation` which isn't a version.

Please note that this change is probably too naive as markers, that actually compare versions using the inequality operator would not normalize those version strings via `pep440.parseVersion` anymore.

Should we add this to this PR? I just wanted to start with the minimal set of changes that fixes the issue for me and pass the current test suite.

```
error:
       … while calling the 'foldl'' builtin

         at /nix/store/0i9l98icvw67mdnhx8q095xsw63yg660-source/lib/pep440.nix:176:27:

          175|   */
          176|   compareVersions = a: b: foldl' (acc: comp: if acc != 0 then acc else comp) 0 [
             |                           ^
          177|     # mixing dev/pre/post like:

       … while evaluating a branch condition

         at /nix/store/0i9l98icvw67mdnhx8q095xsw63yg660-source/lib/pep440.nix:62:5:

           61|     in
           62|     if length ra == 0 || length rb == 0 then 0 else
             |     ^
           63|     (

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: value is a string while a set was expected
```