### PR TITLE
Add dynamic type lookups to evalMarkers

### DIFF
--- a/lib/pep508.nix
+++ b/lib/pep508.nix
@@ -71,8 +71,14 @@ let
     if isMarkerVariable value then value
     else fromJSON (if singleTicked != null then "\"" + head singleTicked + "\"" else value);
 
-  compareOps = pep440.comparators // {
-    "==" = x: y: x == y; # Simple equality
+  comparators = {
+    "==" = a: b: a == b;
+    "!=" = a: b: a != b;
+    "<=" = a: b: a <= b;
+    ">=" = a: b: a >= b;
+    "<" = a: b: a < b;
+    ">" = a: b: a > b;
+    "===" = throw "Arbitrary equality clause not supported";
   };
 
   boolOps = {
@@ -471,7 +477,13 @@ fix (self:
     in
     if value.type == "compare" then
       (
-        compareOps.${value.op} x y
+        if value.lhs.type == "version" || value.rhs.type == "version" then
+          (
+            pep440.comparators.${value.op} x y
+          ) else
+          (
+            comparators.${value.op} x y
+          )
       )
     else if value.type == "boolOp" then
       (


### PR DESCRIPTION
This way we're not assuming as much about the comparison operators and have much better support for comparing primitive types.

Closes https://github.com/adisbladis/pyproject.nix/pull/5