### PR TITLE
Migrate from the determinatesystems installer to cachix

### DIFF
--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -47,10 +47,18 @@ jobs:
       - name: Run tests
         run: nix develop -c nix-unit --flake .#libTests
 
+  collect:
+    runs-on: ubuntu-latest
+    needs:
+      - nix-unit
+      - nix-build
+    steps:
+      - run: true
+
   deploy-pages:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    needs: [nix-build, nix-unit]
+    needs: collect
     steps:
     - uses: actions/checkout@v3
     - name: Install Nix

--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -14,9 +14,13 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/install-nix-action@v20
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v12
+        with:
+          name: adisbladis
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - id: set-matrix
         name: Generate Nix Matrix
         run: |
@@ -30,18 +34,26 @@ jobs:
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/install-nix-action@v20
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v12
+        with:
+          name: adisbladis
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build -L ".#${{ matrix.attr }}"
 
   nix-unit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/install-nix-action@v20
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v12
+        with:
+          name: adisbladis
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Build shell
         run: nix develop -c true
       - name: Run tests
@@ -61,9 +73,13 @@ jobs:
     needs: collect
     steps:
     - uses: actions/checkout@v3
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: cachix/install-nix-action@v20
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: cachix/cachix-action@v12
+      with:
+        name: adisbladis
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Run build
       run: nix build -L .#doc
     - name: Deploy


### PR DESCRIPTION
The most "magic" thing about it is how it turns your tail latency absolutely terrible and causes jobs to fail spuriously because of API rate limits.

Cachix probably gives us slightly worse performance in the common case but much better tail latency.