### PR TITLE
selectWheel: Add type checking and fix docs

### DIFF
--- a/lib/pypa.nix
+++ b/lib/pypa.nix
@@ -322,10 +322,10 @@ lib.fix (self: {
 
   /* Select compatible wheels from a list and return them in priority order.
 
-     Type: selectWheels :: derivation -> [ AttrSet ] -> [ AttrSet ]
+     Type: selectWheels :: AttrSet -> derivation -> [ AttrSet ] -> [ AttrSet ]
 
      Example:
-     # selectWheels pkgs.python3 [ (pypa.parseWheelFileName "Pillow-9.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl") ]
+     # selectWheels (lib.systems.elaborate "x86_64-linux") [ (pypa.parseWheelFileName "Pillow-9.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl") ]
      [ (pypa.parseWheelFileName "Pillow-9.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl") ]
   */
   selectWheels =
@@ -335,43 +335,52 @@ lib.fix (self: {
     python:
     # List of files as parsed by parseWheelFileName
     files:
-    let
-      # Get sorting/filter criteria fields
-      withSortedTags = map
-        (file:
-          let
-            abiCompatible = self.isABITagCompatible python file.abiTag;
+    if ! lib.isAttrs platform
+    then
+      throw ''
+        SelectWheel was called with wrong type for its first argument 'platform'.
+        Pass only elaborated platforms.
+        Example:
+          `lib.systems.elaborate "x86_64-linux"`
+      ''
+    else
+      let
+        # Get sorting/filter criteria fields
+        withSortedTags = map
+          (file:
+            let
+              abiCompatible = self.isABITagCompatible python file.abiTag;
 
-            # Filter only compatible tags
-            languageTags = filter (self.isPythonTagCompatible python) file.languageTags;
-            # Extract the tag as a number. E.g. "37" is `toInt "37"` and "none"/"any" is 0
-            languageTags' = map (tag: if tag == "none" then 0 else toInt tag.version) languageTags;
+              # Filter only compatible tags
+              languageTags = filter (self.isPythonTagCompatible python) file.languageTags;
+              # Extract the tag as a number. E.g. "37" is `toInt "37"` and "none"/"any" is 0
+              languageTags' = map (tag: if tag == "none" then 0 else toInt tag.version) languageTags;
 
-          in
-          {
-            bestLanguageTag = head (sort (x: y: x > y) languageTags');
-            compatible = abiCompatible && length languageTags > 0 && lib.any (self.isPlatformTagCompatible platform python.stdenv.cc.libc) file.platformTags;
-            inherit file;
-          })
-        files;
+            in
+            {
+              bestLanguageTag = head (sort (x: y: x > y) languageTags');
+              compatible = abiCompatible && length languageTags > 0 && lib.any (self.isPlatformTagCompatible platform python.stdenv.cc.libc) file.platformTags;
+              inherit file;
+            })
+          files;
 
-      # Only consider files compatible with this interpreter
-      compatibleFiles = filter (file: file.compatible) withSortedTags;
+        # Only consider files compatible with this interpreter
+        compatibleFiles = filter (file: file.compatible) withSortedTags;
 
-      # Sort files based on their tags
-      sorted = sort
-        (
-          x: y:
-            x.file.distribution > y.file.distribution
-            || x.file.version > y.file.version
-            || (x.file.buildTag != null && (y.file.buildTag == null || x.file.buildTag > y.file.buildTag))
-            || x.bestLanguageTag > y.bestLanguageTag
-        )
-        compatibleFiles;
+        # Sort files based on their tags
+        sorted = sort
+          (
+            x: y:
+              x.file.distribution > y.file.distribution
+              || x.file.version > y.file.version
+              || (x.file.buildTag != null && (y.file.buildTag == null || x.file.buildTag > y.file.buildTag))
+              || x.bestLanguageTag > y.bestLanguageTag
+          )
+          compatibleFiles;
 
-    in
-    # Strip away temporary sorting metadata
-    map (file': file'.file) sorted
+      in
+      # Strip away temporary sorting metadata
+      map (file': file'.file) sorted
   ;
 
 })

--- a/lib/test_pypa.nix
+++ b/lib/test_pypa.nix
@@ -403,6 +403,11 @@ in
 
     in
     {
+      test_selectWheel_platform_type_error = {
+        expr = selectWheels "x86_64-linux" null null;
+        expectedError.type = "ThrownError";
+        expectedError.msg = "SelectWheel was called with wrong type for its first argument 'platform'";
+      };
       testPyNoneAny = mkTest {
         input = [ "distribution-1.0-1-py37-none-any.whl" "distribution-1.0-1-py38-none-any.whl" ];
         output = [ "distribution-1.0-1-py38-none-any.whl" "distribution-1.0-1-py37-none-any.whl" ];


### PR DESCRIPTION
Thanks to nix amazing error traces it took me quite a while to figure out that my problem was passing a string as platform. I was looking at the wrong places due to this error message:
```
error:
       … while calling the 'map' builtin

         at /nix/store/xaxh4nsa710wsr0d9xk23d7g7hl82gj5-source/lib/pypa.nix:374:5:

          373|     # Strip away temporary sorting metadata
          374|     map (file': file'.file) sorted
             |     ^
          375|   ;

       … while calling the 'sort' builtin

         at /nix/store/xaxh4nsa710wsr0d9xk23d7g7hl82gj5-source/lib/pypa.nix:362:16:

          361|       # Sort files based on their tags
          362|       sorted = sort
             |                ^
          363|         (

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: value is a string while a set was expected
```
Now added an ad-hoc type checking for the platform argument, to prevent others from falling into the same trap.