### PR TITLE
fix: pep600 parsing of any arch not in pep599

### DIFF
--- a/lib/pep600.nix
+++ b/lib/pep600.nix
@@ -69,7 +69,7 @@ fix (self: {
       false
     else if compareVersions "${sysMajor}.${sysMinor}" "${tagMajor}.${tagMinor}" < 0 then
       false
-    else if pep599.manyLinuxTargetMachines.${tagArch} != platform.parsed.cpu.name then
+    else if (pep599.manyLinuxTargetMachines.${tagArch} or tagArch) != platform.parsed.cpu.name then
       false
     else
       true;


### PR DESCRIPTION
e.g. riscv64 which is now offered by uv:

```
    { url = "https://files.pythonhosted.org/packages/22/47/b67296c62381b8369f082a33d9fdcb7c579ad9922bcce7b09cd4af935dfa/uv-0.8.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5313ee776ad65731ffa8ac585246f987d3a2bf72e6153c12add1fff22ad6e500", size = 18398665, upload-time = "2025-07-24T21:14:18.399Z" },
```