### PR TITLE
fix: prefer architecture-specific wheels over universal for macOS

### DIFF
--- a/lib/test_pypa.nix
+++ b/lib/test_pypa.nix
@@ -512,8 +512,8 @@ in
       testZmqCPythonDarwin311 = mkTest {
         input = zmqWheels;
         output = [
-          "pyzmq-24.0.1-cp311-cp311-macosx_10_15_universal2.whl"
           "pyzmq-24.0.1-cp311-cp311-macosx_10_9_x86_64.whl"
+          "pyzmq-24.0.1-cp311-cp311-macosx_10_15_universal2.whl"
         ];
         python = mocks.cpythonDarwin311;
       };


### PR DESCRIPTION
This is what poetry also seems to do. It should lead to smaller downloads if both are available and avoiding universal wheels that are actually just arm64 or x86_64, which I've seen in the wild.

I've seen this with depthai for example: https://github.com/luxonis/depthai/issues/1239