### PR TITLE
docs(mkApplication): clarify callPackage util

### DIFF
--- a/build/util/default.nix
+++ b/build/util/default.nix
@@ -17,10 +17,12 @@
     # Example
 
     ```nix
-    util.mkApplication {
+    let
+        util = pkgs.callPackage pyproject-nix.build.util { };
+    in util.mkApplication {
       venv = pythonSet.mkVirtualEnv "mkApplication-check-venv" {
         pip = [ ];
-      }
+      };
       package = pythonSet.pip;
     }
     =>


### PR DESCRIPTION
I was struggling with weird errors because I had not called util
appropriately. It was not obvious by reading the docs that `build.util`
had to be used with `callPackage` before using its functions.

@moduon MT-1075
