### PR TITLE
fix null for non-existing optional-dependencies section

### DIFF
--- a/build/lib/resolvers.nix
+++ b/build/lib/resolvers.nix
@@ -47,7 +47,7 @@ in
             "Extra/group name '${name'}' does not match either extra or dependency group in package ${pkg.pname}"
             concatMap
             (name: recurse name extra'.${name})
-            (attrNames extra')
+            (if extra' != null then (attrNames extra') else [ ])
           ++ concatMap (name: recurse name group'.${name}) (
             if group' != null then (attrNames group') else [ ]
           )


### PR DESCRIPTION

once a dependency-group exists, but there is no optional-dependencies section
```
       … while calling the 'concatMap' builtin
         at /nix/store/9xj3zr4a4lg4xfpsv246iv59b9wf0hww-source/build/lib/resolvers.nix:40:12:
           39|         ++ concatMap (name: recurse name dependencies.${name}) (attrNames dependencies)
           40|         ++ concatMap (
             |            ^
           41|           name':

       … while calling anonymous lambda
         at /nix/store/9xj3zr4a4lg4xfpsv246iv59b9wf0hww-source/build/lib/resolvers.nix:41:11:
           40|         ++ concatMap (
           41|           name':
             |           ^
           42|           let

       … while calling the 'concatMap' builtin
         at /nix/store/9xj3zr4a4lg4xfpsv246iv59b9wf0hww-source/build/lib/resolvers.nix:46:11:
           45|           in
           46|           throwIf (extra' == null && group' == null)
             |           ^
           47|             "Extra/group name '${name'}' does not match either extra or dependency group in package ${pkg.pname}"

       … while calling the 'attrNames' builtin
         at /nix/store/9xj3zr4a4lg4xfpsv246iv59b9wf0hww-source/build/lib/resolvers.nix:50:14:
           49|             (name: recurse name extra'.${name})
           50|             (attrNames extra')
             |              ^
           51|           ++ concatMap (name: recurse name group'.${name}) (

       … while evaluating the argument passed to builtins.attrNames

       error: expected a set but found null: null
```