### PR TITLE
re-add buildInputs with root cause fix

### DIFF
--- a/build/packages.nix
+++ b/build/packages.nix
@@ -4,7 +4,7 @@
 }:
 let
   inherit (resolvers) resolveCyclic resolveNonCyclic;
-  inherit (lib) makeScope concatStringsSep;
+  inherit (lib) makeScope concatStringsSep unique;
 
   mkResolveBuildSystem =
     set:
@@ -62,13 +62,16 @@ let
           ];
 
           env = {
-            NIX_PYPROJECT_DEPS = concatStringsSep ":" (pkgsFinal.resolveVirtualEnv spec);
+            NIX_PYPROJECT_DEPS = concatStringsSep ":" (unique (pkgsFinal.resolveVirtualEnv spec));
             dontMoveLib64 = true;
             mkVirtualenvFlags = concatStringsSep " " (
               map (path: "--skip ${path}") finalAttrs.venvSkip
               ++ map (pat: "--ignore-collisions ${pat}") finalAttrs.venvIgnoreCollisions
             );
           };
+
+          # expose the buildInputs - avoid "Argument list too long"
+          buildInputs = unique (pkgsFinal.resolveVirtualEnv spec);
         });
 
       hooks = pkgsFinal.callPackage ./hooks { };


### PR DESCRIPTION
https://github.com/pyproject-nix/pyproject.nix/commit/f91edf6a888b75437d959502d2935f7e90578054 removed the buildInputs and just fixed the symptoms. Removing buildInputs make the life of others harder, especially SBOM tools which require the information in a programmatic way instead of string contexts

the rootcause are duplicates - which should get fixed instead

<img width="787" height="215" alt="image" src="https://github.com/user-attachments/assets/0496eb73-2d0f-4099-8cc7-ee3c7b0affbb" />
