### PR TITLE
util.filterPythonInterpreters: sort by version descending

### DIFF
--- a/lib/test_util.nix
+++ b/lib/test_util.nix
@@ -43,8 +43,8 @@
           inherit pythonInterpreters;
         });
         expected = map toString [
-          pythonInterpreters.python312
           pythonInterpreters.python313
+          pythonInterpreters.python312
         ];
       };
     };

--- a/lib/util.nix
+++ b/lib/util.nix
@@ -4,13 +4,14 @@
   ...
 }:
 let
-  inherit (builtins) all attrNames concatMap;
-  inherit (lib) hasSuffix;
+  inherit (builtins) all attrValues sort;
+  inherit (lib) filterAttrs hasSuffix mapAttrs;
 in
 {
   /**
     Filter Python interpreter derivations from an attribute set based on
-    python-requires constraints.
+    python-requires constraints. Returns list of interpreter derivations
+    sorted by version descending.
 
     # Example:
     ```nix
@@ -20,9 +21,9 @@ in
     }
     ->
     [
-      «derivation /nix/store/5iwwrbr1dh1yc63gmz1alsk1d96jgfjy-python3-3.12.11.drv»
-      «derivation /nix/store/6p8y1zwm68kksdrad12ybn7lrvvpgwc5-python3-3.13.8.drv»
       «derivation /nix/store/fvac8j3h7sxqfaw7hllr9cllns34pgcm-python3-3.14.0.drv»
+      «derivation /nix/store/6p8y1zwm68kksdrad12ybn7lrvvpgwc5-python3-3.13.8.drv»
+      «derivation /nix/store/5iwwrbr1dh1yc63gmz1alsk1d96jgfjy-python3-3.12.11.drv»
     ]
     ```
   */
@@ -34,27 +35,31 @@ in
       pre ? false,
       implementation ? "cpython",
     }:
-    concatMap (
-      name:
-      let
-        drv = pythonInterpreters.${name};
-        version = pep440.parseVersion drv.version;
-        pythonVersion = pep440.parseVersion drv.pythonVersion;
-      in
-      if
-        (
-          name != "override"
-          && name != "overrideDerivation"
-          &&
-            # Filter prebuilt pypy derivations & python3Minimal
-            !(hasSuffix "prebuilt" name || hasSuffix "Minimal" name)
-          && (drv.implementation or "") == implementation
-          && (pre || version.pre == null)
-          && all (cond: pep440.comparators.${cond.op} pythonVersion cond.version) requires-python
+    map (attrs: attrs.drv) (
+      sort (a: b: pep440.compareVersions a.version b.version == 1) (
+        attrValues (
+          filterAttrs
+            (
+              name: attrs:
+              let
+                inherit (attrs) drv version;
+              in
+              name != "override"
+              && name != "overrideDerivation"
+              # Filter prebuilt pypy derivations & python3Minimal
+              && !(hasSuffix "prebuilt" name || hasSuffix "Minimal" name)
+              && (drv.implementation or "") == implementation
+              && (pre || version.pre == null)
+              && all (cond: pep440.comparators.${cond.op} version cond.version) requires-python
+            )
+            (
+              mapAttrs (_name: drv: {
+                inherit drv;
+                version = pep440.parseVersion drv.version;
+              }) pythonInterpreters
+            )
         )
-      then
-        [ drv ]
-      else
-        [ ]
-    ) (attrNames pythonInterpreters);
+      )
+    );
+
 }


### PR DESCRIPTION
This sorts the returned list of python interpreters by version descending so you can use `builtins.head` to get the best version.

I came to this from the uv2nix documentation at https://pyproject-nix.github.io/uv2nix/usage/getting-started.html#picking-a-python-interpreter which is incorrect without it.