### PR TITLE
treewide: fix broken \ escapes

### DIFF
--- a/lib/pep440.nix
+++ b/lib/pep440.nix
@@ -144,7 +144,7 @@ fix (self: {
     else
       let
         # Split input into (_, epoch, release, modifiers)
-        tokens = match "(([0-9]+)!)?([^-\+a-zA-Z]+)(.*)" version;
+        tokens = match "(([0-9]+)!)?([^-\\+a-zA-Z]+)(.*)" version;
         tokenAt = elemAt tokens;
 
         # Segments

--- a/lib/pep508.nix
+++ b/lib/pep508.nix
@@ -494,7 +494,7 @@ in
           }
         else
           (
-            if match ".+\/.+" input != null then
+            if match ".+/.+" input != null then
               # Input is a bare URL
               {
                 packageSegment = null;

--- a/lib/pypa.nix
+++ b/lib/pypa.nix
@@ -30,7 +30,7 @@ let
   matchWheelFileName = match "([^-]+)-([^-]+)(-([[:digit:]][^-]*))?-([^-]+)-([^-]+)-(.+).whl";
 
   # PEP-625 only specifies .tar.gz as valid extension but .zip is also fairly widespread.
-  matchSdistFileName = match "([^-]+)-(.+)(\.tar\.gz|\.zip)";
+  matchSdistFileName = match "([^-]+)-(.+)(\\.tar\\.gz|\\.zip)";
 
   matchMacosTag = match "macosx_([0-9]+)_([0-9]+)_(.+)";
 
@@ -65,7 +65,7 @@ lib.fix (self: {
   normalizePackageName =
     let
       concatDash = concatStringsSep "-";
-      splitSep = split "[-_\.]+";
+      splitSep = split "[-_\\.]+";
     in
     name: toLower (concatDash (filter isString (splitSep name)));
 


### PR DESCRIPTION
Some of those are useless, some should be \\. to actually match a literal dot. Identified by recent changes in Lix.