### PR TITLE
Use uvBuildHook for cross compilation, fix cross

### DIFF
--- a/build/default.nix
+++ b/build/default.nix
@@ -3,7 +3,7 @@
 lib.fix (self: {
   packages = import ./packages.nix {
     inherit (self.lib) resolvers;
-    inherit lib;
+    inherit lib pyproject-nix;
   };
   lib = import ./lib { inherit lib pyproject-nix; };
   hacks = import ./hacks;

--- a/build/hooks/default.nix
+++ b/build/hooks/default.nix
@@ -7,25 +7,49 @@
   stdenv,
   hooks,
   runCommand,
+  pyproject-nix,
   # Note: Deprecated in 25.05 and slated for removal.
   # Only used for old nixpkgs compat.
   substituteAll ? null,
-  replaceVars ? script: replacements: substituteAll ({
-    # Nixpkgs older than 24.11 does not have replaceVars.
-    # This is a "we have replaceVars at home"
-    src = script;
-  } // replacements),
+  replaceVars ?
+    script: replacements:
+    substituteAll (
+      {
+        # Nixpkgs older than 24.11 does not have replaceVars.
+        # This is a "we have replaceVars at home"
+        src = script;
+      }
+      // replacements
+    ),
 }:
 let
+  inherit (pyproject-nix.lib.pep599) manyLinuxTargetMachines;
+  inherit (builtins) functionArgs;
+  inherit (pkgs) buildPackages;
+  inherit (lib) optionalString;
+
   # Set with fallback for old nixpkgs compat
   pythonOnBuildForHost = python.pythonOnBuildForHost or python.pythonForBuild;
-
-  inherit (builtins) functionArgs;
-
-  inherit (pkgs) buildPackages;
   pythonSitePackages = python.sitePackages;
 
   isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+
+  # Make build backends and uv's interpreter discovery see the target platform.
+  crossSetup = optionalString isCross (
+    let
+      inherit (stdenv.hostPlatform) parsed;
+      machdep = if stdenv.hostPlatform.isWindows then "win32" else parsed.kernel.name;
+      pythonHostPlatform = "${machdep}-${
+        manyLinuxTargetMachines.${parsed.cpu.name} or parsed.cpu.name
+      }";
+    in
+    ''
+      ${optionalString (stdenv.buildPlatform.isLinux || !stdenv.hostPlatform.isLinux) "export _PYTHON_HOST_PLATFORM='${pythonHostPlatform}'"}
+      for f in ${python}/${pythonSitePackages}/_sysconfigdata_*.py; do
+        export _PYTHON_SYSCONFIGDATA_NAME="$(basename "$f" .py)"
+      done
+    ''
+  );
 
   # When cross compiling create a virtual environment for the build.
   #
@@ -75,6 +99,7 @@ in
             "${python}/${python.sitePackages}"
           ]
         );
+        inherit crossSetup;
       };
     } ./pyproject-configure-hook.sh
   ) { };
@@ -219,14 +244,9 @@ in
           ++ extraHooks;
         } ./meta-hook.sh
       )
-      (
-        {
-          python = pythonOnBuildForHost;
-        }
-        // lib.optionalAttrs isCross {
-          pyprojectInstallHook = hooks.pyprojectPypaInstallHook;
-        }
-      );
+      {
+        python = pythonOnBuildForHost;
+      };
 
   /*
     Hook used to build prebuilt wheels.
@@ -281,7 +301,8 @@ in
   /*
     Install hook using pypa/installer.
 
-    Used instead of `pyprojectInstallHook` for cross compilation support.
+    Kept for backwards compatibility; `pyprojectInstallHook` now handles cross
+    compilation via `_PYTHON_HOST_PLATFORM` set by `pyprojectConfigureHook`.
   */
   pyprojectPypaInstallHook = callPackage (
     { pythonPkgsBuildHost }:

--- a/build/hooks/pyproject-configure-hook.sh
+++ b/build/hooks/pyproject-configure-hook.sh
@@ -12,6 +12,8 @@ pyprojectConfigurePhase() {
   # information from the cross compiled Python.
   export PYTHONPATH=@pythonPath@
 
+  @crossSetup@
+
   # Compile bytecode by default.
   if [ -z "${UV_COMPILE_BYTECODE-}" ]; then
     export UV_COMPILE_BYTECODE=1

--- a/build/packages.nix
+++ b/build/packages.nix
@@ -1,6 +1,7 @@
 {
   lib,
   resolvers,
+  pyproject-nix,
 }:
 let
   inherit (resolvers) resolveCyclic resolveNonCyclic;
@@ -70,7 +71,7 @@ let
           );
         });
 
-      hooks = pkgsFinal.callPackage ./hooks { };
+      hooks = pkgsFinal.callPackage ./hooks { inherit pyproject-nix; };
       inherit (pkgsFinal.hooks)
         pyprojectConfigureHook
         pyprojectBuildHook


### PR DESCRIPTION
Previously it wasn't possible to use the default `uv` build hook for cross, and we needed to fall back to `pypa/build` & `pypa/installer`.

I'll not deprecate those hooks quite yet, but at some point I will.